### PR TITLE
Fixed typographical error, changed absolutly to absolutely in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ GET     '/api/1/players/usernames'                                   => ['notAUs
 ___
 ## Configuration
 
-First of all, the configuration process is absolutly optional.
+First of all, the configuration process is absolutely optional.
 
 If you don't give Nodulator a config, it will assume you want to use
 [SqlMem](#sqlmem) DB system, with no persistance at all. Usefull for heavy tests periods.


### PR DESCRIPTION
@Champii, I've corrected a typographical error in the documentation of the [Nodulator](https://github.com/Champii/Nodulator) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
